### PR TITLE
add install method by homebrew

### DIFF
--- a/docs/02-getting-started/01-install/03-install-by-homebrew.md
+++ b/docs/02-getting-started/01-install/03-install-by-homebrew.md
@@ -1,6 +1,5 @@
 # Install by Homebrew
 
-
 ## Installation
 ```
 brew tap starcoinorg/starcoin

--- a/docs/02-getting-started/01-install/03-install-by-homebrew.md
+++ b/docs/02-getting-started/01-install/03-install-by-homebrew.md
@@ -1,0 +1,14 @@
+# Install by Homebrew
+
+
+## Installation
+```
+brew tap starcoinorg/starcoin
+brew install starcoin
+```
+
+
+## Upgrade
+```
+brew upgrade starcoin
+```

--- a/docs/02-getting-started/01-install/README.md
+++ b/docs/02-getting-started/01-install/README.md
@@ -5,6 +5,7 @@ This article guides you on how to install starcoin.
 1. Download the binary for your operating system from Github's [releases](https://github.com/starcoinorg/starcoin/releases) page. Starcoin supports Windows/Mac/Linux, unzip the binary and put it into the system bin path.
 2. Or [build from source](./build).
 3. Or [install by docker](./install-by-docker).
+4. Or [install by homebrew for macOS](./install-by-homebrew)
 
 
 :::note

--- a/i18n/zh/docusaurus-plugin-content-docs/current/02-getting-started/01-install/03-install-by-homebrew.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/02-getting-started/01-install/03-install-by-homebrew.md
@@ -1,6 +1,5 @@
 # Install by Homebrew
 
-
 ## 安装
 ```
 brew tap starcoinorg/starcoin

--- a/i18n/zh/docusaurus-plugin-content-docs/current/02-getting-started/01-install/03-install-by-homebrew.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/02-getting-started/01-install/03-install-by-homebrew.md
@@ -1,0 +1,14 @@
+# Install by Homebrew
+
+
+## 安装
+```
+brew tap starcoinorg/starcoin
+brew install starcoin
+```
+
+
+## 升级
+```
+brew upgrade starcoin
+```

--- a/i18n/zh/docusaurus-plugin-content-docs/current/02-getting-started/01-install/README.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/02-getting-started/01-install/README.md
@@ -5,6 +5,7 @@
 1. 从 github 的 [releases](https://github.com/starcoinorg/starcoin/releases) 页面下载适合自己操作系统的二进制，starcoin 同时支持 Windows、Mac 和 Linux, 将解压后将二进制放入系统命令路径中。
 2. 或者 [从源码构建](./build)。
 3. 或者 [通过 Docker 安装](./install-by-docker)。
+4. 或者 [通过 Homebrew 安装](./install-by-homebrew)。
 
 
 :::note


### PR DESCRIPTION
Now we can install starcoin by homebrew for macOS users.