### PR TITLE
[WIP] add quick start chapter

### DIFF
--- a/docs/03-move/01-prepare-move-env.md
+++ b/docs/03-move/01-prepare-move-env.md
@@ -1,31 +1,40 @@
 # Setting up Move develop environment
 
-## Installation
+## Install mpm
+Move Package Manager(mpm) is a command line tool to develop move projects, like Cargo for Rust, or NPM for NodeJS.
 
-1. Run [`dev_setup.sh`](https://github.com/starcoinorg/starcoin-framework/blob/main/scripts/dev_setup.sh)(automated installation script) of starcoin-framework, which contains the move prover environment setup
+### Install using the convenience script
+1. Run [`scripts/dev_setup.sh`](https://github.com/starcoinorg/starcoin-framework/blob/main/scripts/dev_setup.sh)(automated installation script) of starcoin-framework, which contains mpm, Rust, PATH config and the move prover environment setup.
 ```
 curl -s https://raw.githubusercontent.com/starcoinorg/starcoin-framework/main/scripts/dev_setup.sh | bash /dev/stdin -b -t
 ```
 
-2. Download from the release page of [starcoiorg/starcoin](https://github.com/starcoinorg/starcoin).
+The command above will install mpm and Rust to default location. It also set the PATH env. Check more arguments in shell script.
 
-3.
+### Install from binary
+Download `mpm-[your_os]-latest.zip` from the release page of [starcoiorg/starcoin](https://github.com/starcoinorg/starcoin), unarchive it and add it to PATH env.
+
+### Install from source
+
+From local source code
 ```
 $ git clone https://github.com/starcoinorg/starcoin.git
-$ cargo install --path starcoin/vm/move-package-manager
+$ cd starcoin
+$ cargo install --path vm/move-package-manager
 ```
 
-4.
+Or from remote git repo
 ```
 $ cargo install --git https://github.com/starcoinorg/starcoin move-package-manager --bin mpm
 ```
 
-This will install the `mpm` binary in your Cargo binary directory. On macOS and Linux this is usually *~/.cargo/bin*. You'll want to make sure this location is in your `PATH` environment variable.
+This will install the `mpm` binary in your Cargo binary directory. On macOS and Linux this is usually *~/.cargo/bin/*. You'll want to make sure this location is in your `PATH` environment variable.
 
+### Summary
 Now you should be able to run the `mpm`:
 ```
 $ mpm
-move-package-manager 1.11.7-rc
+move-package-manager 1.11.11
 Starcoin Core Dev <dev@starcoin.org>
 CLI frontend for the Move compiler and VM
 
@@ -34,8 +43,12 @@ USAGE:
   ...
 ```
 
+## Install IDE plugin
 
-# Set up env for move prover.
+### VS Code
+Search `starcoin-id` in Extensions.
+
+## Set up env for move prover
 
 1. Run [`dev_setup.sh`](https://github.com/starcoinorg/starcoin-framework/blob/main/scripts/dev_setup.sh)(automated installation script) of starcoin-framework
 ```
@@ -45,4 +58,3 @@ USAGE:
 When the above command is executed, type `boogie /version` and if the output is similar to "Boogie program verifier version X.X.X", then the installation has been successful.
 
 Note that currently Move Prover can only run under UNIX-based operating systems (e.g. Linux, macOS). Windows users can run it by installing WSL.
-

--- a/i18n/zh/docusaurus-plugin-content-docs/current/03-move/01-prepare-move-env.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/03-move/01-prepare-move-env.md
@@ -1,31 +1,43 @@
 # 设置 Move 开发环境
 
-## 下载
+## 安装 mpm
+Move Package Manager（mpm）是一个命令行工具，用于开发 Move 项目。可以类比 Rust 的 Cargo，或 NodeJS 的 npm。
 
-1. 运行 starcoin-framework 下的 [`dev_setup.sh`](https://github.com/starcoinorg/starcoin-framework/blob/main/scripts/dev_setup.sh)（自动化安装脚本），它包含了 mpm 的安装以及 move-prover 的依赖安装：
+选择下面的一种方法安装
+
+### 通过安装脚本安装
+
+运行 starcoin-framework 下的 [`scripts/dev_setup.sh`](https://github.com/starcoinorg/starcoin-framework/blob/main/scripts/dev_setup.sh)（自动化安装脚本），它包含了 mpm、Rust、环境变量配置以及 Move Prover 工具的依赖安装：
 ```
-curl -s https://raw.githubusercontent.com/starcoinorg/starcoin-framework/main/scripts/dev_setup.sh | bash /dev/stdin -b -t
+curl -s https://raw.githubusercontent.com/starcoinorg/starcoin-framework/main/scripts/dev_setup.sh | bash /dev/stdin -b -t -p
 ```
 
-2. 从 [starcoiorg/starcoin](https://github.com/starcoinorg/starcoin) 的发布页面下载
+上面的给定的参数会在默认位置安装 mpm、Rust的安装，并配置环境变量。更多参数可以打开脚本文件查看。
 
-3.
+### 通过预编译二进制包安装
+从 [starcoiorg/starcoin](https://github.com/starcoinorg/starcoin) 的发布页面下载 `mpm-[your_os]-latest.zip` 并解压，然后手动添加到 PATH。
+
+### 从源码编译安装
+
+可以从本地源码
 ```
 $ git clone https://github.com/starcoinorg/starcoin.git
-$ cargo install --path starcoin/vm/move-package-manager
+$ cd starcoin
+$ cargo install --path vm/move-package-manager
 ```
 
-4.
+也可以从git仓库源码
 ```
 $ cargo install --git https://github.com/starcoinorg/starcoin move-package-manager --bin mpm
 ```
 
-这将在 Cargo 二进制目录中安装 `mpm` 二进制文件。在 macOS和 Linux 上，这个目录通常是 *~/.Cargo/bin*。你需要确保该位置在你的 `PATH` 环境变量中。
+这将在 Cargo 的 bin 目录中安装 `mpm` 二进制文件。在 macOS 和 Linux 上，这个目录通常是 *~/.Cargo/bin/*。你需要确保该位置在你的 `PATH` 环境变量中。
 
+### 小结
 现在，你应该能够运行 `mpm`：
 ```
 $ mpm
-move-package-manager 1.11.7-rc
+move-package-manager 1.11.11
 Starcoin Core Dev <dev@starcoin.org>
 CLI frontend for the Move compiler and VM
 
@@ -33,7 +45,14 @@ USAGE:
     mpm [OPTIONS] <SUBCOMMAND>
   ...
 ```
-# 设置 Move Prover 环境
+
+## 安装 IDE 插件
+
+### VS Code
+在插件市场中搜索 starcoin-ide。点击安装即可。
+
+
+## 设置 Move Prover 环境
 
 1. 运行 starcoin-framework 下的 dev_setup.sh（自动化安装脚本）
 


### PR DESCRIPTION
想添加一个quick start章节。
原因是：
1. 目前的 03-move 章节对于新手来说有些跳跃，不太连贯。
2. 有的章节是从 Move-book 直接复制的，里面的命令还是 move-cli的，会让用户很困扰。
3. 通过阅读 [move-book](https://move-book.com/cn/index.html) 和 [官方教程](https://move-language.github.io/move/) 来了解move的话，教程里的命令想跑在 starcoin 上还需要事先了解 mpm 是 move-cli 的超集，有割裂感。
 
构想的章节结构如下（当然不完善）：
- 03 Move in Action
  - **Move 环境搭建**（在原有基础上改进）
  - **快速开始**（新加章节，融合目前的 Move语言包、Move包管理器、部署你的第一个智能合约、与合约交互 这几个文档的基础内容）
  - **Move 包管理器用户指南**（现有章节）
  - **Move 语言**（就是介绍语法之类的，看看是直接引用 Move-book 和 Move官方教程，还是自己写）
    - 基础类型
    - 认识Ability
    - ...
  - **进阶知识**
    - 合约升级（现在的 How to upgrade Move Module 移动到这里）
    - For solidity developer（现在的 For solidity developer）
    - Module 依赖（现在的 Understanding module dependency）
  - **Starcoin Move Framework**（现有章节）
  - **Move 测试**（现有章节）
  - **更多 Move 例子**（现有章节）
  - **Move How-To**
    - How to design permission system with Capability（现有章节）
    - How to handle the mapping requirement（现有章节）
  - **Move 规范语言和Move Prover**（现有章节）

期望能达到循序渐进的效果。

这个PR里，我试着写一下快速开始这部分。

Steps：
1. improve Move env setting up in 03-move
2. write quick start chapter