### PR TITLE
fix:-f is not the command of 'mpm pacakage test' and typo in English version

### DIFF
--- a/docs/03-move/97-move-test/01-move-unit-test.md
+++ b/docs/03-move/97-move-test/01-move-unit-test.md
@@ -208,10 +208,10 @@ module 0x1::MyModule {
 
 ## Running Tests
 
-You can then run these tests with the `move package test` command:
+You can then run these tests with the `mpm package test` command:
 
 ```
-$ move package test
+$ mpm package test
 BUILDING MoveStdlib
 BUILDING TestExample
 Running Move unit tests
@@ -224,10 +224,10 @@ Test result: OK. Total tests: 3; passed: 3; failed: 0
 
 ## Using Test Flags
 
-`-f <str>` or `--filter <str>`
-This will only run tests whose fully qualified name contains `<str>`. For example if we wanted to only run tests with `"zero_coin"` in their name:
+Type `<str>` following `mpm package test`, which will only run tests whose fully qualified name contains `<str>`. For example, if we want to only run tests with `"zero_coin"` in their name:
+
 ```
-$ move package test -f zero_coin
+$ mpm package test zero_coin
 CACHED MoveStdlib
 BUILDING TestExample
 Running Move unit tests
@@ -241,7 +241,7 @@ Test result: OK. Total tests: 2; passed: 2; failed: 0
 This bounds the number of instructions that can be executed for any one test to `<bound>`:
 
 ```
-$ move package test -i 0
+$ mpm package test -i 0
 CACHED MoveStdlib
 BUILDING TestExample
 Running Move unit tests
@@ -275,7 +275,7 @@ Test result: FAILED. Total tests: 3; passed: 0; failed: 3
 With these flags you can gather statistics about the tests run and report the runtime and instructions executed for each test. For example, if we wanted to see the statistics for the tests in the example above:
 
 ```
-$ move package test -s
+$ mpm package test -s
 CACHED MoveStdlib
 BUILDING TestExample
 Running Move unit tests
@@ -316,7 +316,7 @@ module 0x1::MyModule {
 we would get get the following output when running the tests:
 
 ```
-$ move package test -g
+$ mpm package test -g
 CACHED MoveStdlib
 BUILDING TestExample
 Running Move unit tests

--- a/i18n/zh/docusaurus-plugin-content-docs/current/03-move/97-move-test/01-move-unit-test.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/03-move/97-move-test/01-move-unit-test.md
@@ -202,14 +202,14 @@ Test result: OK. Total tests: 3; passed: 3; failed: 0
 
 ### 测试命令的参数
 
-#### `-f <str> | --filter <str>`
+#### ` <str>`
 
-这将只运行名称中包含有 `<str>` 的测试。
+在 `mpm package test` 后面加上`<str>`，这将只运行名称中包含有 `<str>` 的测试。
 
 例如，如果我们想只运行名称中含有 "zero_coin "的测试。
 
 ```
-$ mpm package test -f zero_coin
+$ mpm package test zero_coin
 CACHED MoveStdlib
 BUILDING TestExample
 Running Move unit tests


### PR DESCRIPTION
1, -f is not the command of 'mpm pacakage test'.
2, the command, 'move package' in English version, should be 'mpm package'.