### PR TITLE
Add the description of genesis_config2 for private network

### DIFF
--- a/docs/02-getting-started/02-setup/07-private-network.md
+++ b/docs/02-getting-started/02-setup/07-private-network.md
@@ -32,8 +32,8 @@ For example, to generate a custom network named `my_chain` with id `123`:
 starcoin_generator -n my_chain:123 --genesis-config halley genesis_config
 ```
 
-This command uses the built-in `halley` network configuration as a template and generates a configuration file named `genesis_config.json` in the `~/.starcoin/my_chain` directory.
-Parameters in the `~/.starcoin/my_chain/genesis_config.json` file can be modified with an editor.
+This command uses the built-in `halley` network configuration as a template and generates configuration files named `genesis_config.json` and `genesis_config2.json` in the `~/.starcoin/my_chain` directory.
+Parameters in the `~/.starcoin/my_chain/genesis_config.json` and `~/.starcoin/my_chain/genesis_config2.json` file can be modified with an editor.
 
 Note: If you don't want the configuration file to be generated in the default `~/.starcoin/<CHAIN_NAME>` directory, you can also specify the directory with the `-d` option.
 
@@ -47,10 +47,10 @@ starcoin_generator -n my_chain:123 genesis
 
 This command generates the genesis block according to the genesis configuration file generated earlier.
 
-The genesis configuration file in the above example is `~/.starcoin/my_chain/genesis_config.json`. Of course, you can also place the `genesis_config.json` file in another location and specify it with an absolute path, for example:
+The genesis configuration file in the above example is `~/.starcoin/my_chain/genesis_config2.json`. Of course, you can also place the `genesis_config2.json` file in another location and specify it with an absolute path, for example:
 
 ```shell
-starcoin_generator -n my_chain:123 --genesis-config /data/conf/my_chain/genesis_config.json genesis
+starcoin_generator -n my_chain:123 --genesis-config /data/conf/my_chain/genesis_config2.json genesis
 ```
 
 ## Running custom network nodes
@@ -83,10 +83,11 @@ starcoin -n my_chain:123 --seed /ip4/ip of genesis seed/tcp/9840/p2p/12D3KooWR1p
 
 First, start one node as the genesis seed, which is already started if you follow the steps, and check your local ip address.
 
-Second, copy the *genesis_config.json* configuration file of the genesis seed node to a new directory:
+Second, copy the *genesis_config.json* and *genesis_config2.json*configuration file of the genesis seed node to a new directory:
 
 ```shell
 cp ~/.starcoin/my_chain/genesis_config.json ~/.starcoin1/my_chain/
+cp ~/.starcoin/my_chain/genesis_config2.json ~/.starcoin1/my_chain/
 ```
 
 Third, start other node using docker with following command:

--- a/i18n/zh/docusaurus-plugin-content-docs/current/02-getting-started/02-setup/07-private-network.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/02-getting-started/02-setup/07-private-network.md
@@ -32,8 +32,8 @@ starcoin_generator -n <CHAIN_NAME>:<CHAIN_ID> --genesis-config <GENESIS_CONFIG> 
 starcoin_generator -n my_chain:123 --genesis-config halley genesis_config
 ```
 
-该命令将内置的 `halley` 网络配置作为模板，生成一个名为 `genesis_config.json` 配置文件在 `~/.starcoin/my_chain` 目录下。
-可以用编辑器修改 `~/.starcoin/my_chain/genesis_config.json` 文件中的参数。
+该命令将内置的 `halley` 网络配置作为模板，生成名为 `genesis_config.json` 和 `genesis_config2.json` 的配置文件在 `~/.starcoin/my_chain` 目录下。
+可以用编辑器修改 `~/.starcoin/my_chain/genesis_config.json` 和 `~/.starcoin/my_chain/genesis_config2.json` 文件中的参数。
 
 注：如果不想配置文件生成在默认的 `~/.starcoin/<CHAIN_NAME>` 目录下，也可以通过 `-d` 选项指定目录。
 
@@ -47,11 +47,11 @@ starcoin_generator -n my_chain:123 genesis
 
 该命令根据前面生成的创世配置文件来生成创世区块。
 
-上面例子中的创世配置文件是 `~/.starcoin/my_chain/genesis_config.json`。
-当然，也可以将 `genesis_config.json` 文件放置在其他位置，然后通过绝对路径指定，比如：
+上面例子中的创世配置文件是 `~/.starcoin/my_chain/genesis_config2.json`。
+当然，也可以将 `genesis_config2.json` 文件放置在其他位置，然后通过绝对路径指定，比如：
 
 ```shell
-starcoin_generator -n my_chain:123 --genesis-config /data/conf/my_chain/genesis_config.json genesis
+starcoin_generator -n my_chain:123 --genesis-config /data/conf/my_chain/genesis_config2.json genesis
 ```
 
 ## 运行自定义网络节点
@@ -84,10 +84,11 @@ starcoin -n my_chain:123 --seed /ip4/创世seed节点的IP地址/tcp/9840/p2p/12
 
 第一步，启动一个节点作为创世种子节点，如果跟着上面的步骤来，那它已经启动了，这时候检查您的本地 IP 地址，第三步会用到
 
-第二步，把创世的种子节点（seed node）的 *genesis_config.json* 配置文件 `cp` 到新的目录下
+第二步，把创世的种子节点（seed node）的 *genesis_config.json* 和 *genesis_config2.json* 配置文件 `cp` 到新的目录下
 
 ```shell
 cp ~/.starcoin/my_chain/genesis_config.json ~/.starcoin1/my_chain/
+cp ~/.starcoin/my_chain/genesis_config2.json ~/.starcoin1/my_chain/
 ```
 
 第三步，用 docker 来启动其他节点，命令如下：


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated private network setup to use two genesis configuration files, with guidance on editing, generating, and referencing both.
  * Revised example commands to point to the appropriate configuration file; paths and flags adjusted accordingly.
  * Expanded seed/bootstrapping steps to copy both configuration files into target directories.
  * Mirrored all updates in the Chinese documentation to keep multilingual guides consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->